### PR TITLE
Modernize Travis configuration

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,16 +1,9 @@
-language: cpp
-compiler:
-  - clang
+language: julia
+julia:
+  - 0.4
+  - nightly
 notifications:
   email: false
-env:
-  matrix:
-    - JULIAVERSION="juliareleases"
-before_install:
-  - sudo add-apt-repository ppa:staticfloat/julia-deps -y
-  - sudo add-apt-repository ppa:staticfloat/${JULIAVERSION} -y
-  - sudo apt-get update -qq -y
-  - sudo apt-get install libpcre3-dev julia -y
-  - if [[ -a .git/shallow ]]; then git fetch --unshallow; fi
-script:
-  - julia -e 'Pkg.init(); Pkg.clone(pwd()); Pkg.test("ValueOrientedRiskManagementInsurance")'
+#script: # the default script does the following
+#  - if [[ -a .git/shallow ]]; then git fetch --unshallow; fi
+#  - julia -e 'Pkg.init(); Pkg.clone(pwd()); Pkg.test("ValueOrientedRiskManagementInsurance")'


### PR DESCRIPTION
Using `language: julia` will allow you to continue testing against Julia 0.4 even after
the juliareleases PPA updates to 0.5, and the nightlies here are much more up-to-date
than the julianightlies from the PPA. You can also enable OSX testing by setting `os:`.
